### PR TITLE
Update to alliance descriptions

### DIFF
--- a/xspo-alliance-members.json
+++ b/xspo-alliance-members.json
@@ -2,8 +2,8 @@
     "adapools": {
         "about": {
             "name": "xSPO Alliance",
-            "description_short": "[xSPO] is a fun group of pools with XS (eXtra Small) stakes of less than 1m ADA",
-            "description_long": "[xSPO] is short for XS (eXtra Small) Stake Pool Operators. We are a group of Stake Pool Operators running pools with small stake/pledge (smaller than 1m ADA). Join us to connect and meet similar sized and like minded peers. Our mission: Having fun while helping each other grow.",
+            "description_short": "[xSPO] is a fun group of pools that joined with XS (eXtra Small) stakes of less than 1m ADA",
+            "description_long": "[xSPO] is short for XS (eXtra Small) Stake Pool Operators. We are a group of Stake Pool Operators running pools that joined with small stake/pledge (smaller than 1m ADA). Join us to connect and meet similar sized and like minded peers. Our mission: Having fun while helping each other grow.",
             "website": "https://discord.gg/VGMnRjeH9d",
             "url_png_icon_64x64": "https://git.io/JWAcd",
             "url_png_logo": "https://git.io/JWAch",


### PR DESCRIPTION
Added a note that pools joined with <1M active stake. 
Purpose is to show intent to grow and allow space for pools that have grown to continue to support the alliance