### PR TITLE
pixel->9000

### DIFF
--- a/xspo-alliance-members.json
+++ b/xspo-alliance-members.json
@@ -356,7 +356,7 @@
       "98": {
         "pool_id": "4f3410f074e7363091a1cc1c21b128ae423d1cce897bd19478e534bb",
         "member_since": "2021-07-21",
-        "name": "PIXEL (Pixel pool)"
+        "name": "9000 (ADA 9000)"
       },
       "99": {
         "pool_id": "74d66da57368e12f12bd07f303da7f8cd3c2494af9e32e4dea210c58",


### PR DESCRIPTION
4f3410f074e7363091a1cc1c21b128ae423d1cce897bd19478e534bb pool_id maps to the ticker 9000 instead of pixel. You can verify here https://cardanoscan.io/pool/4f3410f074e7363091a1cc1c21b128ae423d1cce897bd19478e534bb.